### PR TITLE
ci: move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/deploy-widget.yml
+++ b/.github/workflows/deploy-widget.yml
@@ -26,10 +26,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -44,10 +44,10 @@ jobs:
         run: ls -la ./public/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './public'
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Bump JavaScript actions still on the deprecated Node 20 runtime to their Node 24-native versions after the 2026-06-26 cutover:

- actions/checkout@v4 -> @v6
- astral-sh/setup-node@v4 -> @v5
- actions/configure-pages@v4 -> @v6
- actions/upload-pages-artifactv3 -> @V5

Closes #6.